### PR TITLE
(SIMP-99) Created RPM for simp-rsync-clamav

### DIFF
--- a/.rsync.facl
+++ b/.rsync.facl
@@ -5,6 +5,27 @@ user::rwx
 group::r-x
 other::---
 
+# file: CONTRIBUTING.md
+# owner: root
+# group: root
+user::rwx
+group::r--
+other::r--
+
+# file: LICENSE
+# owner: root
+# group: root
+user::rwx
+group::r--
+other::r--
+
+# file: README.md
+# owner: root
+# group: root
+user::rwx
+group::r--
+other::r--
+
 # file: RedHat
 # owner: root
 # group: root
@@ -46,13 +67,6 @@ other::---
 user::rwx
 group::r-x
 other::---
-
-# file: RedHat/7/bind_dns/default/named/dev
-# owner: root
-# group: root
-user::rwx
-group::r-x
-other::r-x
 
 # file: RedHat/7/bind_dns/default/named/var
 # owner: root
@@ -180,20 +194,6 @@ user::rw-
 group::r--
 other::---
 
-# file: RedHat/7/bind_dns/default/named/var/tmp
-# owner: root
-# group: 25
-user::rwx
-group::r-x
-other::---
-
-# file: RedHat/7/bind_dns/default/named/var/log
-# owner: root
-# group: 25
-user::rwx
-group::r-x
-other::---
-
 # file: RedHat/7/bind_dns/default/named/var/run
 # owner: root
 # group: 25
@@ -213,13 +213,6 @@ other::---
 # group: 25
 user::rw-
 group::r--
-other::---
-
-# file: RedHat/7/bind_dns/default/named/var/run/dbus
-# owner: root
-# group: 25
-user::rwx
-group::r-x
 other::---
 
 # file: RedHat/7/bind_dns/default/named/etc


### PR DESCRIPTION
ClamAV is under a different license than the rest of the Rsync module
and needed to be split out into its own sub-RPM.

SIMP-99 #close #comment Fixed for SIMP5.X
