### PR TITLE
(SIMP-2819) Added README info on the '.shares'

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,28 @@ baseurl=http://vault.centos.org/6.0/os/x86_64
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-6
 gpgcheck=1
 ```
+
+### Usage
+
+To get full functionality out of the SIMP modules, particularly, the `simp`
+module itself, you need to perform the following operations:
+
+**NOTE:** If you're using the RPM, it does all of this for you and is the
+recommended method for installing these files.
+
+#### Copy the Repository into Place
+
+  1. ``mkdir -p /var/simp/environments/simp``
+  2. Copy the ``environments/simp/rsync`` directory from this repository into ``/var/simp/environments/simp``
+  3. ``cd /var/simp/environments/simp/rsync``
+  4. ``setfacl --restore=.rsync.facl 2>/dev/null``
+
+#### Restore the SELinux Contexts
+
+  1. ``cd`` into the cloned repository
+  2. ``cd build/selinux``
+  3. ``make -f /usr/share/selinux/devel/Makefile``
+  4. ``cp *.pp /usr/share/selinux/packages``
+  5. ``/usr/sbin/semodule -n -i /usr/share/selinux/packages/simp-rsync.pp``
+  6. ``/usr/sbin/load_policy``
+  7. ``/sbin/fixfiles -R simp-rsync restore

--- a/build/simp-rsync.spec
+++ b/build/simp-rsync.spec
@@ -23,7 +23,7 @@
 
 Summary: SIMP rsync repository
 Name: simp-rsync
-Version: 6.0.0
+Version: 6.0.1
 Release: 0%{?dist}
 License: Apache License, Version 2.0 and ISC
 Group: Applications/System
@@ -193,6 +193,10 @@ if [ $1 -eq 0 ] ; then
 fi
 
 %changelog
+* Mon Mar 20 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.1-0
+- Updated the README that is delivered with the SIMP rsync environments to talk
+  a bit about the shares structure and to encourage users to read the HOWTO
+
 * Wed Jan 11 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
 - Now works with multiple environments
 - Removed all legacy 'fix' code

--- a/environments/simp/rsync/README
+++ b/environments/simp/rsync/README
@@ -5,3 +5,19 @@ Globals => Any shares that are not bound by OS specific issues
 <OperatingSystem>/<MajorRelease> => Shares that are specific to the OS and release
 
 No other directory structure is supported at this time
+
+## Updating The Shares
+
+Care must be taken with updating the rsync shares in a SIMP system.
+
+In particular, you need to ensure that any directory where rsync will be
+sharing content contains a `.shares` file.
+
+This structure is used by the `simp_rsync_environments` fact to provide the
+Puppet server with an understanding of what has the potential of being shared
+out on the sysetm and where it is located. This means that you can easily move
+your rsync shares to other servers and that they are not bound to the Puppet
+server.
+
+See the HOWTO on working with Rsync shares in the main SIMP documentation for a
+full description and examples.


### PR DESCRIPTION
Added some info to the README that is delivered onto the system to help
users understand the directory structure and to encourage them to head
to the main documentation for full details and examples.

SIMP-2819 #comment Update to point to main docs